### PR TITLE
Widen blog text width

### DIFF
--- a/distill_blog/_site.yml
+++ b/distill_blog/_site.yml
@@ -1,5 +1,6 @@
 name: "distill_blog"
 title: "Nelson\\Nygaard R Training"
+theme: theme.css
 description: |
   Nelson\\Nygaard R Training
 output_dir: "../docs"

--- a/distill_blog/theme.css
+++ b/distill_blog/theme.css
@@ -33,11 +33,6 @@ html {
   --navbar-font:     sans-serif;  /* websites + blogs only */
 }
 
-/*--ATTEMPTING TO WIDEN MIDDLE COLUMN -- */
-d-article p, d-article ul, d-article ol, d-article blockquote {
-  --width:          2000px;
-}
-
 /*-- ARTICLE METADATA --*/
 d-byline {
   --heading-size:    0.6rem;
@@ -80,4 +75,6 @@ d-appendix {
 
 /*-- Additional custom styles --*/
 /* Add any additional CSS rules below                      */
-
+d-article > p, d-article > ul, d-article > ol{
+  grid-column-end: 14;
+}


### PR DESCRIPTION
This PR adds theme document to yaml file, this is required for site to read the file according to documentation. It also edits the width of the text in the articles by altering css directly in theme.css


added this to the theme file -- 
`d-article > p, d-article > ul, d-article > ol{
  grid-column-end: 14;
}`

setting the number of grid columns the p divs take up is what fixes it, rather than setting a width. this is sort of weird and definitely based on distill's specific grid css layout.